### PR TITLE
make mimetype `text/plain` to be `text/latex`

### DIFF
--- a/julia/TeXmacsJulia.jl
+++ b/julia/TeXmacsJulia.jl
@@ -217,7 +217,7 @@ const tm_mimetypes = [
     MIME("image/jpg"),
     MIME("text/html"), 
     MIME("text/markdown"), 
-    MIME("text/plain")]
+    MIME("text/latex")]
 
 function display(d::InlineDisplay, x)
     for m in tm_mimetypes


### PR DESCRIPTION
Last element of `tm_mimetypes` should be `text/latex`, since `text/plain` is the fallback mimetype, which is possibly a typo.